### PR TITLE
chore: Use PyPI OIDC to publish

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -2,7 +2,11 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]  # Trigger only when a release is published, not when a release is drafted
+
+permissions:
+  contents: write  # Needed to upload artifacts to the release
+  id-token: write  # Needed for OIDC PyPI publishing
 
 jobs:
   build_deploy:
@@ -35,7 +39,5 @@ jobs:
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: true
-    - name: Deploy to PyPI
-      run: |
-        poetry publish -r testpypi -u "__token__" -p "${{ secrets.TEST_PYPI_TOKEN }}"
-        poetry publish -u "__token__" -p "${{ secrets.PYPI_TOKEN }}"
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@v1.8.5


### PR DESCRIPTION
Once this is merged, the PyPI token secret can be removed from the repo.

https://pypi.org/manage/project/meltanolabs-tap-snowflake/settings/publishing
