### PR TITLE
Making introspection more efficient

### DIFF
--- a/tap_snowflake/client.py
+++ b/tap_snowflake/client.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Iterable, List, Tuple
 from uuid import uuid4
 import datetime
+import singer
 
 import sqlalchemy
 from singer_sdk import SQLConnector, SQLStream, metrics

--- a/tap_snowflake/client.py
+++ b/tap_snowflake/client.py
@@ -20,6 +20,7 @@ from singer_sdk.streams.core import REPLICATION_FULL_TABLE, REPLICATION_INCREMEN
 import singer_sdk.helpers._typing
 from snowflake.sqlalchemy import URL
 from sqlalchemy.sql import text
+LOGGER = singer.get_logger()
 
 unpatched_conform = singer_sdk.helpers._typing._conform_primitive_property
 

--- a/tap_snowflake/client.py
+++ b/tap_snowflake/client.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any, Iterable, List, Tuple
 from uuid import uuid4
 import datetime
-import singer
 
 import sqlalchemy
 from singer_sdk import SQLConnector, SQLStream, metrics
@@ -21,7 +20,6 @@ from singer_sdk.streams.core import REPLICATION_FULL_TABLE, REPLICATION_INCREMEN
 import singer_sdk.helpers._typing
 from snowflake.sqlalchemy import URL
 from sqlalchemy.sql import text
-LOGGER = singer.get_logger()
 
 unpatched_conform = singer_sdk.helpers._typing._conform_primitive_property
 
@@ -112,8 +110,6 @@ class SnowflakeConnector(SQLConnector):
         """
         result: list[dict] = []
         tables = [t.lower() for t in self.config.get("tables", [])]
-        LOGGER.debug("This is the tables: %s", tables)
-        LOGGER.debug("This is the config: %s", self.config)
         result.append(self.config)
         # engine = self.create_sqlalchemy_engine()
         # inspected = sqlalchemy.inspect(engine)

--- a/tap_snowflake/client.py
+++ b/tap_snowflake/client.py
@@ -114,24 +114,25 @@ class SnowflakeConnector(SQLConnector):
         tables = [t.lower() for t in self.config.get("tables", [])]
         LOGGER.debug("This is the tables: %s", tables)
         LOGGER.debug("This is the config: %s", self.config)
-        engine = self.create_sqlalchemy_engine()
-        inspected = sqlalchemy.inspect(engine)
-        schema_names = [
-            schema_name
-            for schema_name in self.get_schema_names(engine, inspected)
-            if schema_name.lower() != "information_schema"
-        ]
-        LOGGER.debug("This is the schema_names: %s", schema_names)
-        for schema_name in schema_names:
-            # Iterate through each table and view
-            for table_name, is_view in self.get_object_names(
-                engine, inspected, schema_name
-            ):
-                if (not tables) or (f"{schema_name}.{table_name}" in tables):
-                    catalog_entry = self.discover_catalog_entry(
-                        engine, inspected, schema_name, table_name, is_view
-                    )
-                    result.append(catalog_entry.to_dict())
+        result.append(self.config)
+        # engine = self.create_sqlalchemy_engine()
+        # inspected = sqlalchemy.inspect(engine)
+        # schema_names = [
+        #     schema_name
+        #     for schema_name in self.get_schema_names(engine, inspected)
+        #     if schema_name.lower() != "information_schema"
+        # ]
+        # LOGGER.debug("This is the schema_names: %s", schema_names)
+        # for schema_name in schema_names:
+        #     # Iterate through each table and view
+        #     for table_name, is_view in self.get_object_names(
+        #         engine, inspected, schema_name
+        #     ):
+        #         if (not tables) or (f"{schema_name}.{table_name}" in tables):
+        #             catalog_entry = self.discover_catalog_entry(
+        #                 engine, inspected, schema_name, table_name, is_view
+        #             )
+        #             result.append(catalog_entry.to_dict())
 
         return result
 

--- a/tap_snowflake/client.py
+++ b/tap_snowflake/client.py
@@ -13,7 +13,6 @@ from typing import Any, Iterable, List, Tuple
 from uuid import uuid4
 import datetime
 
-from loguru import logger
 import sqlalchemy
 from singer_sdk import SQLConnector, SQLStream, metrics
 from singer_sdk.helpers._batch import BaseBatchFileEncoding, BatchConfig
@@ -119,8 +118,15 @@ class SnowflakeConnector(SQLConnector):
             for schema_name in self.get_schema_names(engine, inspected)
             if schema_name.lower() != "information_schema"
         ]
-        logger.info("This is the schema_names: %s", schema_names)
-        logger.info("This is the tables: %s", tables)
+        #print("This is self.config: %s", self.config)
+        #print(self.config)
+        print("This is the schema_names: %s", schema_names)
+        print("This is the tables: %s", tables)
+        self.logger.info("This is tables")
+        self.logger.info(tables)
+        self.logger.info("This is schema_names")
+        self.logger.info(schema_names)
+        self.logger.info(self.config)
         for schema_name in schema_names:
             # Iterate through each table and view
             for table_name, is_view in self.get_object_names(

--- a/tap_snowflake/client.py
+++ b/tap_snowflake/client.py
@@ -111,6 +111,8 @@ class SnowflakeConnector(SQLConnector):
         """
         result: list[dict] = []
         tables = [t.lower() for t in self.config.get("tables", [])]
+        LOGGER.debug("This is the tables: %s", tables)
+        LOGGER.debug("This is the config: %s", self.config)
         engine = self.create_sqlalchemy_engine()
         inspected = sqlalchemy.inspect(engine)
         schema_names = [
@@ -118,6 +120,7 @@ class SnowflakeConnector(SQLConnector):
             for schema_name in self.get_schema_names(engine, inspected)
             if schema_name.lower() != "information_schema"
         ]
+        LOGGER.debug("This is the schema_names: %s", schema_names)
         for schema_name in schema_names:
             # Iterate through each table and view
             for table_name, is_view in self.get_object_names(

--- a/tests/catalog.json
+++ b/tests/catalog.json
@@ -378,7 +378,7 @@
             "type": ["number"]
           },
           "o_orderdate": {
-            "format": "date-time",
+            "format": "date",
             "type": ["string"]
           },
           "o_orderpriority": {


### PR DESCRIPTION
Previously, we were unnecessarily making calls to get available schemas and iterating through them to find relevant tables. However, now, if a user passes in a schema in the configs, we only introspect on that one schema 