### PR TITLE
feat: Add browser authentication

### DIFF
--- a/tap_snowflake/tap.py
+++ b/tap_snowflake/tap.py
@@ -60,6 +60,16 @@ class TapSnowflake(SQLTap):
             description="The passprhase used to protect the private key",
         ),
         th.Property(
+            "use_browser_authentication",
+            th.BooleanType,
+            required=False,
+            default=False,
+            description=(
+                "If authentication should be done using SSO (via external browser). "
+                "See See SSO browser authentication."
+            )
+        ),
+        th.Property(
             "account",
             th.StringType,
             required=True,

--- a/tap_snowflake/tap.py
+++ b/tap_snowflake/tap.py
@@ -66,7 +66,7 @@ class TapSnowflake(SQLTap):
             default=False,
             description=(
                 "If authentication should be done using SSO (via external browser). "
-                "See See SSO browser authentication."
+                "See SSO browser authentication."
             )
         ),
         th.Property(


### PR DESCRIPTION
# Description
* Copy code over from target-snowflake https://github.com/MeltanoLabs/target-snowflake/pull/260, now there is parity between how the target & tap can connect to snowflake (3 ways: password, key pair & browser authentications)
* This refactor uses `Enum` for `auth_method` for greater type safety.