### PR TITLE
feat: Replace black, flake8, isort & pydocstyle with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,5 +19,3 @@ repos:
   rev: v1.11.2
   hooks:
   - id: mypy
-    additional_dependencies:
-    - types-requests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+  - id: check-json
+  - id: check-toml
+  - id: check-yaml
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.6.7
+  hooks:
+  - id: ruff
+    args: [--fix, --exit-non-zero-on-fix]
+  - id: ruff-format
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.11.2
+  hooks:
+  - id: mypy
+    additional_dependencies:
+    - types-requests

--- a/poetry.lock
+++ b/poetry.lock
@@ -93,41 +93,6 @@ files = [
 ]
 
 [[package]]
-name = "black"
-version = "22.12.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
-    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
-    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
-    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
-    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
-    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
-    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
-    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
-    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
-    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
-    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
-    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
-typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "certifi"
 version = "2024.8.30"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -428,22 +393,6 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", 
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
-name = "flake8"
-version = "3.9.2"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-files = [
-    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
-    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
-]
-
-[package.dependencies]
-mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.7.0,<2.8.0"
-pyflakes = ">=2.3.0,<2.4.0"
-
-[[package]]
 name = "fs"
 version = "2.4.16"
 description = "Python's filesystem abstraction layer"
@@ -608,20 +557,6 @@ files = [
 ]
 
 [[package]]
-name = "isort"
-version = "5.13.2"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.6)"]
-
-[[package]]
 name = "joblib"
 version = "1.4.2"
 description = "Lightweight pipelining with Python functions"
@@ -683,17 +618,6 @@ files = [
 [package.dependencies]
 importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 referencing = ">=0.31.0"
-
-[[package]]
-name = "mccabe"
-version = "0.6.1"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = "*"
-files = [
-    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
-    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
-]
 
 [[package]]
 name = "mypy"
@@ -768,17 +692,6 @@ files = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
 name = "pkgutil-resolve-name"
 version = "1.3.10"
 description = "Resolve a name to an object."
@@ -843,17 +756,6 @@ files = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.7.0"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
-    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"
@@ -862,34 +764,6 @@ python-versions = ">=3.8"
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
-]
-
-[[package]]
-name = "pydocstyle"
-version = "6.3.0"
-description = "Python docstring style checker"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
-    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
-]
-
-[package.dependencies]
-snowballstemmer = ">=2.2.0"
-
-[package.extras]
-toml = ["tomli (>=1.2.3)"]
-
-[[package]]
-name = "pyflakes"
-version = "2.3.1"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
-    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 
 [[package]]
@@ -1430,17 +1304,6 @@ files = [
 ]
 
 [[package]]
-name = "snowballstemmer"
-version = "2.2.0"
-description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
-optional = false
-python-versions = "*"
-files = [
-    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
-    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
-]
-
-[[package]]
 name = "snowflake-connector-python"
 version = "3.12.1"
 description = "Snowflake Connector for Python"
@@ -1757,4 +1620,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "0cc0ecb8af7936b3fd09265a42ba1286fee5d582a96fd1a7246286816a932baf"
+content-hash = "3696276542f86fdb6389fcb5f923f83f60c5184bd266a8bc534cbf57b23e4e69"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1199,6 +1199,33 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.6.7"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.6.7-py3-none-linux_armv6l.whl", hash = "sha256:08277b217534bfdcc2e1377f7f933e1c7957453e8a79764d004e44c40db923f2"},
+    {file = "ruff-0.6.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c6707a32e03b791f4448dc0dce24b636cbcdee4dd5607adc24e5ee73fd86c00a"},
+    {file = "ruff-0.6.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:533d66b7774ef224e7cf91506a7dafcc9e8ec7c059263ec46629e54e7b1f90ab"},
+    {file = "ruff-0.6.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:17a86aac6f915932d259f7bec79173e356165518859f94649d8c50b81ff087e9"},
+    {file = "ruff-0.6.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b3f8822defd260ae2460ea3832b24d37d203c3577f48b055590a426a722d50ef"},
+    {file = "ruff-0.6.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9ba4efe5c6dbbb58be58dd83feedb83b5e95c00091bf09987b4baf510fee5c99"},
+    {file = "ruff-0.6.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:525201b77f94d2b54868f0cbe5edc018e64c22563da6c5c2e5c107a4e85c1c0d"},
+    {file = "ruff-0.6.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8854450839f339e1049fdbe15d875384242b8e85d5c6947bb2faad33c651020b"},
+    {file = "ruff-0.6.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2f0b62056246234d59cbf2ea66e84812dc9ec4540518e37553513392c171cb18"},
+    {file = "ruff-0.6.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b1462fa56c832dc0cea5b4041cfc9c97813505d11cce74ebc6d1aae068de36b"},
+    {file = "ruff-0.6.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:02b083770e4cdb1495ed313f5694c62808e71764ec6ee5db84eedd82fd32d8f5"},
+    {file = "ruff-0.6.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0c05fd37013de36dfa883a3854fae57b3113aaa8abf5dea79202675991d48624"},
+    {file = "ruff-0.6.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f49c9caa28d9bbfac4a637ae10327b3db00f47d038f3fbb2195c4d682e925b14"},
+    {file = "ruff-0.6.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a0e1655868164e114ba43a908fd2d64a271a23660195017c17691fb6355d59bb"},
+    {file = "ruff-0.6.7-py3-none-win32.whl", hash = "sha256:a939ca435b49f6966a7dd64b765c9df16f1faed0ca3b6f16acdf7731969deb35"},
+    {file = "ruff-0.6.7-py3-none-win_amd64.whl", hash = "sha256:590445eec5653f36248584579c06252ad2e110a5d1f32db5420de35fb0e1c977"},
+    {file = "ruff-0.6.7-py3-none-win_arm64.whl", hash = "sha256:b28f0d5e2f771c1fe3c7a45d3f53916fc74a480698c4b5731f0bea61e52137c8"},
+    {file = "ruff-0.6.7.tar.gz", hash = "sha256:44e52129d82266fa59b587e2cd74def5637b730a69c4542525dfdecfaae38bd5"},
+]
+
+[[package]]
 name = "setuptools"
 version = "74.1.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1730,4 +1757,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "0b09c9a594855f5f813d7872f4fa3aa7ed22c24ea6d7d4015170703018bd2036"
+content-hash = "0cc0ecb8af7936b3fd09265a42ba1286fee5d582a96fd1a7246286816a932baf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,18 @@ ignore = [
 ]
 select = ["ALL"]
 
+[tool.ruff.format]
+quote-style = "double"
+exclude = ["*.pyi"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["target_snowflake"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
 [build-system]
 requires = ["poetry-core>=1.0.8", "poetry-dynamic-versioning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,37 @@ pydocstyle = "^6.1.1"
 singer-sdk = {extras = ["testing"], version = "*"}
 tox = "^3.24.4"
 types-requests = "^2.26.1"
+ruff = "^0.6.7"
 
 [tool.isort]
 profile = "black"
 multi_line_output = 3 # Vertical Hanging Indent
 src_paths = "tap_snowflake"
+
+[tool.ruff]
+line-length = 88
+src = ["target_snowflake"]
+target-version = "py38"
+
+[tool.ruff.lint]
+ignore = [
+    "ANN101",  # missing-type-self
+    "ANN102",  # missing-type-cls
+    "ANN201",
+    "ANN001",
+    "ANN401",
+    "TD",
+    "D",
+    "FIX",
+    "S608",
+    "EM101",
+    "EM102",
+    "SLF001",
+]
+select = ["ALL"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["target_snowflake"]
 
 [build-system]
 requires = ["poetry-core>=1.0.8", "poetry-dynamic-versioning"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,7 @@ sqlalchemy = "~=2.0.34"
 cryptography = ">=3.4.6,<42.0.0"
 
 [tool.poetry.group.dev.dependencies]
-black = "^22.3.0"
-flake8 = "^3.9.2"
-isort = "^5.10.1"
 mypy = "^0.991"
-pydocstyle = "^6.1.1"
 singer-sdk = {extras = ["testing"], version = "*"}
 tox = "^3.24.4"
 types-requests = "^2.26.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,18 +41,11 @@ target-version = "py38"
 
 [tool.ruff.lint]
 ignore = [
-    "ANN101",  # missing-type-self
-    "ANN102",  # missing-type-cls
-    "ANN201",
     "ANN001",
     "ANN401",
-    "TD",
-    "D",
-    "FIX",
     "S608",
-    "EM101",
-    "EM102",
     "SLF001",
+    "EM101",
 ]
 select = ["ALL"]
 

--- a/tap_snowflake/client.py
+++ b/tap_snowflake/client.py
@@ -54,7 +54,7 @@ singer_sdk.helpers._typing._conform_primitive_property = patched_conform
 
 
 class SnowflakeAuthMethod(Enum):
-    """Supported methods to authenticate to snowflake"""
+    """Supported methods to authenticate to snowflake."""
 
     BROWSER = 1
     PASSWORD = 2
@@ -94,7 +94,7 @@ class TableProfile:
 class SnowflakeConnector(SQLConnector):
     """Connects to the Snowflake SQL source."""
 
-    def get_private_key(self):
+    def get_private_key(self) -> bytes:
         """Get private key from the right location."""
         try:
             encoded_passphrase = self.config["private_key_passphrase"].encode()
@@ -293,7 +293,7 @@ class SnowflakeStream(SQLStream):
     connector_class = SnowflakeConnector
 
     @property
-    def is_sorted(self):
+    def is_sorted(self) -> bool:
         """Is sorted."""
         return bool(self.replication_key)
 
@@ -366,9 +366,8 @@ class SnowflakeStream(SQLStream):
         https://docs.snowflake.com/en/user-guide-data-unload.html
         """
         if context:
-            raise NotImplementedError(
-                f"Stream '{self.name}' does not support partitioning.",
-            )
+            msg = f"Stream '{self.name}' does not support partitioning."
+            raise NotImplementedError(msg)
         yield from self.get_batches_from_internal_user_stage(batch_config, context)
 
     def _get_full_table_copy_statement(
@@ -526,9 +525,8 @@ class SnowflakeStream(SQLStream):
                 not support partitioning.
         """
         if context:
-            raise NotImplementedError(
-                f"Stream '{self.name}' does not support partitioning.",
-            )
+            msg = f"Stream '{self.name}' does not support partitioning."
+            raise NotImplementedError(msg)
 
         selected_column_names = self.get_selected_schema()["properties"].keys()
         table = self.connector.get_table(

--- a/tap_snowflake/client.py
+++ b/tap_snowflake/client.py
@@ -494,7 +494,7 @@ class SnowflakeStream(SQLStream):
             Path(local_path).mkdir(parents=True, exist_ok=True)
             for result in results:
                 stage_path = result[0]
-                file_name = Path.name(stage_path)
+                file_name = Path(stage_path).name
                 self.connector.execute(  # type: ignore[attr-defined]
                     text(f"get '@~/{stage_path}' '{root}/{sync_id}'"),
                 )

--- a/tap_snowflake/client.py
+++ b/tap_snowflake/client.py
@@ -102,7 +102,7 @@ class SnowflakeConnector(SQLConnector):
             encoded_passphrase = None
 
         if "private_key_path" in self.config:
-            with Path.open(self.config["private_key_path"], "rb") as key:
+            with Path(self.config["private_key_path"].open("rb") as key:
                 key_content = key.read()
         else:
             key_content = self.config["private_key"].encode()

--- a/tap_snowflake/tap.py
+++ b/tap_snowflake/tap.py
@@ -67,7 +67,7 @@ class TapSnowflake(SQLTap):
             description=(
                 "If authentication should be done using SSO (via external browser). "
                 "See SSO browser authentication."
-            )
+            ),
         ),
         th.Property(
             "account",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,6 @@
 import os
 
 from singer_sdk.testing import SuiteConfig, get_tap_test_class
-
 from tap_snowflake.tap import TapSnowflake
 
 SAMPLE_CONFIG = {
@@ -29,7 +28,7 @@ TestTapSnowflake = get_tap_test_class(
     tap_class=TapSnowflake,
     config=SAMPLE_CONFIG,
     suite_config=SuiteConfig(
-        max_records_limit=100, ignore_no_records_for_streams=["tpch_sf1-lineitem"]
+        max_records_limit=100, ignore_no_records_for_streams=["tpch_sf1-lineitem"],
     ),
     catalog="tests/catalog.json",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,7 @@ whitelist_externals = poetry
 commands =
     poetry install -v
     poetry run pytest
-    poetry run black --check tap_snowflake/
-    poetry run flake8 tap_snowflake
-    poetry run pydocstyle tap_snowflake
+    poetry run ruff check
     poetry run mypy tap_snowflake
 
 [testenv:pytest]
@@ -29,25 +27,16 @@ commands =
 # To execute, run `tox -e format`
 commands =
     poetry install -v
-    poetry run black tap_snowflake/
-    poetry run isort tap_snowflake
+    poetry run ruff --fix
 
 [testenv:lint]
 # Raise an error if lint and style standards are not met.
 # To execute, run `tox -e lint`
 commands =
     poetry install -v
-    poetry run flake8 tap_snowflake
-    poetry run pydocstyle tap_snowflake
+    poetry run ruff check
     # refer to mypy.ini for specific settings
     poetry run mypy tap_snowflake
 
-[flake8]
-ignore = W503
-max-line-length = 88
-max-complexity = 10
-docstring-convention = google
 
-[pydocstyle]
-convention = google
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,6 @@ commands =
 # To execute, run `tox -e lint`
 commands =
     poetry install -v
-    poetry run black --check --diff tap_snowflake/
-    poetry run isort --check tap_snowflake
     poetry run flake8 tap_snowflake
     poetry run pydocstyle tap_snowflake
     # refer to mypy.ini for specific settings

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,8 @@ commands =
 # To execute, run `tox -e format`
 commands =
     poetry install -v
-    poetry run ruff --fix
+    poetry run ruff check --fix
+    poetry run ruff format
 
 [testenv:lint]
 # Raise an error if lint and style standards are not met.

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands =
 commands =
     poetry install -v
     poetry run ruff check
+    poetry run ruff format --check
     # refer to mypy.ini for specific settings
     poetry run mypy tap_snowflake
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ commands =
     poetry install -v
     poetry run pytest
     poetry run ruff check
+    poetry run ruff format --check
     poetry run mypy tap_snowflake
 
 [testenv:pytest]


### PR DESCRIPTION
# Description

* Replaces black, flake8, pydocstyle & isort with Ruff
* Adds `.pre-commit-config.yaml` file
* Fix some linting issues highlighted by Ruff in default setting, while disabling a 5 rules. The following rules are disabled: 
    - ANN001
    - ANN401
    - S608
    - SLF001
    - EM101
    
`ANN001` * `ANN401` are disabled because the codebase has a few instances where params / return values don't specify type or return `Any`. 

`S608` flags string based queries. It will require a deeper refactor to leverage sqlalchemy exclusively. 

`SFL001` flags accesses to private members. This is done to patch `_confirm_primitive_property`.

`EM101` flags strings passed to Exceptions, which I felt was safe to do.

closes: https://github.com/MeltanoLabs/tap-snowflake/issues/43