### PR TITLE
chore: pin GitHub Actions versions to commit hashes

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+    - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
       with:
         name: Packages
         path: dist


### PR DESCRIPTION
This will help prevent attacks such as [this one](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/).

Dependabot is able to update these versions automatically, and it will preserve the readable version comments.
